### PR TITLE
fix VUE bug: imported vue.js twice

### DIFF
--- a/templates/tasks/tripitaka.html
+++ b/templates/tasks/tripitaka.html
@@ -310,12 +310,9 @@
   </div>
 {% endblock %}
 {% block foot_script %}
-<script src="{{ static('js/vue.js') }}"></script>
 <script src="{{ static('js/element-ui.js') }}"></script>
 <script src="{{ static('custom/js/punct.js') }}"></script>
 <script src="{{ static('custom/js/lqtripitaka.js') }}"></script>
-<script src="/static/js/element-ui.js"></script>
-
   <script>
     var app = new Vue({
       el: '#tripitaka',


### PR DESCRIPTION
由于重复引入vue.js，使得页面的文字校对反馈窗口无法弹出。